### PR TITLE
TextAgents: fish/food rename + wrap food at edges

### DIFF
--- a/public/Flora.Canvas.TextAgents.html
+++ b/public/Flora.Canvas.TextAgents.html
@@ -41,11 +41,12 @@
         var crumbs = [];
         for (var i = 0; i < TOTAL_CRUMBS; i++) {
           crumbs.push(this.add('Walker', {
-            text: 'crumb',
+            text: 'food',
             width: 26,
             height: 18,
             color: [255, 255, 255],
             perlinSpeed: 0.001,
+            wrapWorldEdges: true,
             location: new Flora.Vector(rand(0, world.width), rand(0, world.height))
           }));
         }
@@ -56,7 +57,7 @@
           // sprite per unique text/font/size/color combination.
           var grey = 110 + rand(0, 4) * 20;
           this.add('Agent', {
-            text: 'ant',
+            text: 'fish',
             width: 14,
             height: rand(10, 18),
             color: [grey, grey, grey],

--- a/public/Flora.TextAgents.html
+++ b/public/Flora.TextAgents.html
@@ -37,11 +37,12 @@
         var crumbs = [];
         for (var i = 0; i < TOTAL_CRUMBS; i++) {
           crumbs.push(this.add('Walker', {
-            text: 'crumb',
+            text: 'food',
             width: 26,
             height: 18,
             color: [255, 255, 255],
             perlinSpeed: 0.001,
+            wrapWorldEdges: true,
             location: new Flora.Vector(rand(0, world.width), rand(0, world.height))
           }));
         }
@@ -52,7 +53,7 @@
           // sprite per unique text/font/size/color combination.
           var grey = 110 + rand(0, 4) * 20;
           this.add('Agent', {
-            text: 'ant',
+            text: 'fish',
             width: 14,
             height: rand(10, 18),
             color: [grey, grey, grey],


### PR DESCRIPTION
Carries forward local edits to both text-entity demos that predated the #16 merge.

- Renames the creatures from **ant/crumb** to **fish/food** in `Flora.Canvas.TextAgents.html` and `Flora.TextAgents.html`.
- Adds `wrapWorldEdges: true` to the food walkers so they re-enter at the opposite edge like the fish already do, instead of accumulating against a boundary.

Page-only changes (no `src/` touched, no rebuild). Verified both demos live on canvas and DOM: fish/food glyphs render, food walkers wrap, 800 agents on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)